### PR TITLE
use `io.ReadAll` instead of `ioutil.ReadAll`

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,7 +10,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -208,7 +208,7 @@ func readCredentialsCache(cacheFilePath string) (*Credentials, error) {
 	}
 	defer f.Close()
 
-	bytes, err := ioutil.ReadAll(f)
+	bytes, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
As of Go 1.16, the functions provided by`io/ioutil` package have been moved to other packages. I suggest using `io.ReadAll` instead of `ioutil.ReadAll`.